### PR TITLE
Guard import of `UserPotcarFunctional` behind an `if TYPE_CHECKING` block

### DIFF
--- a/doped/vasp.py
+++ b/doped/vasp.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from importlib import resources
 from multiprocessing import cpu_count
 from multiprocessing.pool import Pool
-from typing import Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union, cast, 
 
 import numpy as np
 from monty.io import zopen
@@ -37,6 +37,9 @@ from doped.utils.parsing import (
     _get_defect_supercell_bulk_site_coords,
 )
 from doped.utils.symmetry import _frac_coords_sort_func
+
+if TYPE_CHECKING:
+    from pymatgen.io.vasp.sets import UserPotcarFunctional
 
 _ignore_pmg_warnings()
 warnings.formatwarning = _custom_formatwarning

--- a/doped/vasp.py
+++ b/doped/vasp.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from importlib import resources
 from multiprocessing import cpu_count
 from multiprocessing.pool import Pool
-from typing import TYPE_CHECKING, Optional, Union, cast, 
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 import numpy as np
 from monty.io import zopen

--- a/doped/vasp.py
+++ b/doped/vasp.py
@@ -20,7 +20,7 @@ from monty.serialization import dumpfn, loadfn
 from pymatgen.core import SETTINGS
 from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.inputs import BadIncarWarning, Kpoints, Poscar, Potcar
-from pymatgen.io.vasp.sets import DictSet, UserPotcarFunctional
+from pymatgen.io.vasp.sets import DictSet
 from tqdm import tqdm
 
 from doped import _doped_obj_properties_methods, _ignore_pmg_warnings


### PR DESCRIPTION
This PR seeks to close https://github.com/SMTG-Bham/ShakeNBreak/issues/73, allowing `doped` to function with pymatgen>=5.31.2024.

In short, throughout Pymatgen, type hints are generally guarded behind an `if TYPE_CHECKING` block to ensure that compute time isn't wasted on loading imports during calculations. This is pretty standard practice.

Previously, `pymatgen.io.vasp.sets.UserPotcarFunctional` was not guarded by an `if TYPE_CHECKING` block and could be imported directly. However, in pymatgen==5.3.1.2024, it was guarded in the `if TYPE_CHECKING` block, meaning it can no longer be imported directly. This was the cause of the incompatability.

I have resolved the issue by guarding the import in doped now.